### PR TITLE
Enable better caching by making routes stateless

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -18,6 +18,6 @@ class LoginController extends Controller
 
     public function __construct()
     {
-        $this->middleware(['guest', 'csp'])->except('logout');
+        $this->middleware(['guest', 'security'])->except('logout');
     }
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -38,7 +38,11 @@ class Kernel extends HttpKernel
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ],
+
+        'security' => [
             \App\Http\Middleware\AddSecurityHeaders::class,
+            \Spatie\Csp\AddCspHeaders::class,
         ],
 
         'api' => [
@@ -65,6 +69,5 @@ class Kernel extends HttpKernel
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'cacheResponse' => \Spatie\ResponseCache\Middlewares\CacheResponse::class,
-        'csp' => \Spatie\Csp\AddCspHeaders::class,
     ];
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -46,7 +46,9 @@ class RouteServiceProvider extends ServiceProvider
 
     protected function mapBlogRoutes(): void
     {
-        Route::middleware(['web', 'csp'])
+        Route::middleware($this->statelessMiddleware)
+            ->name('blog.')
+            ->prefix('blog')
             ->namespace($this->namespace)
             ->group(base_path('routes/blog.php'));
     }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -32,7 +32,7 @@ class RouteServiceProvider extends ServiceProvider
 
     protected function mapWebRoutes(): void
     {
-        Route::middleware('web')
+        Route::middleware(['web', 'security'])
             ->namespace($this->namespace)
             ->group(base_path('routes/web.php'));
     }
@@ -53,7 +53,7 @@ class RouteServiceProvider extends ServiceProvider
 
     protected function mapContactRoutes(): void
     {
-        Route::middleware(['web', 'csp'])
+        Route::middleware(['web', 'security'])
             ->namespace($this->namespace)
             ->group(base_path('routes/contact.php'));
     }
@@ -67,7 +67,7 @@ class RouteServiceProvider extends ServiceProvider
 
     protected function mapAdminRoutes(): void
     {
-        Route::middleware(['web', 'csp'])
+        Route::middleware(['web', 'security'])
             ->namespace($this->namespace)
             ->group(base_path('routes/admin.php'));
     }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -32,7 +32,7 @@ class RouteServiceProvider extends ServiceProvider
 
     protected function mapWebRoutes(): void
     {
-        Route::middleware(['web', 'security'])
+        Route::middleware('web')
             ->namespace($this->namespace)
             ->group(base_path('routes/web.php'));
     }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -9,12 +9,19 @@ use Illuminate\Support\Facades\Route;
 
 class RouteServiceProvider extends ServiceProvider
 {
+    protected array $statelessMiddleware = [
+        'security',
+        'cacheResponse',
+        'cache.headers:public;max_age=604800;etag',
+    ];
+
     public function boot(): void
     {
         $this->configureRateLimiting();
 
         $this->routes(function (): void {
             $this->mapWebRoutes();
+            $this->mapPageRoutes();
             $this->mapBlogRoutes();
             $this->mapContactRoutes();
             $this->mapNewsletterRoutes();
@@ -28,6 +35,13 @@ class RouteServiceProvider extends ServiceProvider
         Route::middleware('web')
             ->namespace($this->namespace)
             ->group(base_path('routes/web.php'));
+    }
+
+    protected function mapPageRoutes(): void
+    {
+        Route::middleware($this->statelessMiddleware)
+            ->namespace($this->namespace)
+            ->group(base_path('routes/page.php'));
     }
 
     protected function mapBlogRoutes(): void

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -2,7 +2,15 @@
 
 use App\Http\Controllers\Admin\ArticleController;
 use App\Http\Controllers\Admin\DashboardController;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
+
+Auth::routes([
+    'confirm' => false,
+    'register' => false,
+    'reset' => false,
+    'verify' => false,
+]);
 
 Route::group(['as' => 'admin.', 'middleware' => 'auth'], static function (): void {
     Route::get('admin', DashboardController::class)->name('dashboard');

--- a/routes/blog.php
+++ b/routes/blog.php
@@ -5,24 +5,20 @@ use App\Http\Controllers\ArticleController;
 use App\Http\Controllers\ArticleSeriesController;
 use Illuminate\Support\Facades\Route;
 
-Route::name('blog.')
-    ->prefix('blog')
-    ->middleware(['cacheResponse', 'cache.headers:public;max_age=604800;etag'])
-    ->group(static function (): void {
-        Route::group(['prefix' => 'categories', 'as' => 'categories.'], static function (): void {
-            Route::get('/', [ArticleCategoryController::class, 'index'])->name('index');
-            Route::get('{category}', [ArticleCategoryController::class, 'show'])->name('show');
-        });
+Route::group(['prefix' => 'categories', 'as' => 'categories.'], static function (): void {
+    Route::get('/', [ArticleCategoryController::class, 'index'])->name('index');
+    Route::get('{category}', [ArticleCategoryController::class, 'show'])->name('show');
+});
 
-        Route::group(['prefix' => 'series', 'as' => 'series.'], static function (): void {
-            Route::get('/', [ArticleSeriesController::class, 'index'])->name('index');
-            Route::get('{series}', [ArticleSeriesController::class, 'show'])->name('show');
-        });
+Route::group(['prefix' => 'series', 'as' => 'series.'], static function (): void {
+    Route::get('/', [ArticleSeriesController::class, 'index'])->name('index');
+    Route::get('{series}', [ArticleSeriesController::class, 'show'])->name('show');
+});
 
-        Route::group(['as' => 'articles.'], static function (): void {
-            Route::get('/', [ArticleController::class, 'index'])->name('index');
-            Route::get('{article}', [ArticleController::class, 'show'])
-                ->withoutMiddleware(['cacheResponse', 'cache.headers'])
-                ->name('show');
-        });
-    });
+Route::group(['as' => 'articles.'], static function (): void {
+    Route::get('/', [ArticleController::class, 'index'])->name('index');
+    Route::get('{article}', [ArticleController::class, 'show'])
+        ->middleware('web')
+        ->withoutMiddleware(['cacheResponse', 'cache.headers'])
+        ->name('show');
+});

--- a/routes/blog.php
+++ b/routes/blog.php
@@ -19,6 +19,6 @@ Route::group(['as' => 'articles.'], static function (): void {
     Route::get('/', [ArticleController::class, 'index'])->name('index');
     Route::get('{article}', [ArticleController::class, 'show'])
         ->middleware('web')
-        ->withoutMiddleware(['cacheResponse', 'cache.headers'])
+        ->withoutMiddleware(['cacheResponse', 'cache.headers:public;max_age=604800;etag'])
         ->name('show');
 });

--- a/routes/page.php
+++ b/routes/page.php
@@ -1,0 +1,6 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::redirect('/', '/blog')->name('home');
+Route::view('about', 'pages.about')->name('about');

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,13 +1,5 @@
 <?php
 
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
-
-Auth::routes([
-    'confirm' => false,
-    'register' => false,
-    'reset' => false,
-    'verify' => false,
-]);
 
 Route::feeds();

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,10 +10,4 @@ Auth::routes([
     'verify' => false,
 ]);
 
-Route::middleware(['cacheResponse', 'csp', 'cache.headers:public;max_age=604800;etag'])
-    ->group(function () {
-        Route::redirect('/', '/blog')->name('home');
-        Route::view('about', 'pages.about')->name('about');
-    });
-
 Route::feeds();


### PR DESCRIPTION
- Created `security` middleware group
- Removed `web` middleware group from page and blog routes to remove session cookies and make them 'stateless'